### PR TITLE
Filter by start_date AND end_date

### DIFF
--- a/github_contributions/contributions.py
+++ b/github_contributions/contributions.py
@@ -73,8 +73,8 @@ class GithubContributions(object):
         return streaks
 
     def __str__(self):
-        template = '<GithubContributions {0} days of data ending at {1}>'
-        return template.format(len(self.days), self.end_date)
+        template = '<GithubContributions {0} days of data>'
+        return template.format(len(self.days))
 
     def __repr__(self):
         return self.__str__()

--- a/github_contributions/contributions.py
+++ b/github_contributions/contributions.py
@@ -33,8 +33,8 @@ class GithubContributions(object):
             self.days = _parse_soup(soup)
         self._streaks = None
 
-    def _filter_start_date(self, start_date):
-        self.days = [day for day in self.days if day.date >= start_date]
+    def _filter_date(self, start_date, end_date):
+        self.days = [day for day in self.days if day.date >= start_date and day.date <= end_date]
 
     def today(self):
         """Returns the contribution day object for the current date.

--- a/github_contributions/test/test_integration.py
+++ b/github_contributions/test/test_integration.py
@@ -1,11 +1,22 @@
 from github_contributions import GithubUser
 
 
-def test_integration():
+def test_integration_end_date():
     ''' Get live data from Github for sanity checking '''
 
     user = GithubUser('bcongdon')
     contribs = user.contributions(end_date='2016-01-01')
-    assert len(contribs.days) == 370
-    assert contribs.days[-10].level == 1
-    assert contribs.days[-10].count == 2
+    assert len(contribs.days) == 366
+    assert contribs.days[-10].level == 2
+    assert contribs.days[-10].count == 6
+
+
+def test_integration_start_and_end_date():
+    ''' Get live data from Github for sanity checking '''
+
+    user = GithubUser('bcongdon')
+    contribs = user.contributions(
+        start_date='2019-01-01', end_date='2019-01-02')
+    assert len(contribs.days) == 2
+    assert contribs.days[0].level == 1
+    assert contribs.days[0].count == 2

--- a/github_contributions/user.py
+++ b/github_contributions/user.py
@@ -80,7 +80,7 @@ class GithubUser(object):
 
         # Filter by start_date if necessary
         if start_date:
-            contributions._filter_start_date(start_date)
+            contributions._filter_date(start_date, end_date)
 
         return contributions
 


### PR DESCRIPTION
If I understand your code correctly, you are only filtering by start date, not end date. This PR filters by start and end date. Fixes issue raised in issue #3.

Example:
```python3
from github_contributions import GithubUser

user = GithubUser('juliangaal')

contribs = user.contributions(start_date='2019-01-20', end_date='2019-01-21')
for day in contribs.days:
    print("{} contributions on {}, level {}".format(day.count, day.date, day.level))
```
Output:
```bash
27 contributions on 2019-01-20, level 4
9 contributions on 2019-01-21, level 2
```
Before this commit, the output was 
```bash
27 contributions on 2019-01-20, level 4
9 contributions on 2019-01-21, level 2
0 ....
0 ....
...
0 contributions on 2019-12-31, level 0
```

EDIT: even though your CI is failing, it is working locally